### PR TITLE
Update dev container for better package scanning of Benchling SDK

### DIFF
--- a/examples/chem-sync-local-flask/.devcontainer/devcontainer.json
+++ b/examples/chem-sync-local-flask/.devcontainer/devcontainer.json
@@ -22,8 +22,7 @@
         "python.linting.enabled": true,
         "explorer.excludeGitIgnore": true,
         "python.analysis.packageIndexDepths": [
-          {"name": "benchling_sdk", "depth": 8, "includeAllSymbols": true},
-          {"name": "benchling_api_client", "depth": 6, "includeAllSymbols": true}
+          {"name": "benchling_sdk", "depth": 8, "includeAllSymbols": true}
         ]
       }
     }


### PR DESCRIPTION
The dev container was previously not suggesting imports for packages like `benchling-sdk`. Increase the package scan depth to solve the problem.

After this change:

<img width="923" alt="Screenshot 2024-01-10 at 9 25 35 AM" src="https://github.com/benchling/app-examples-python/assets/1076765/f4ee96d8-cdef-4972-9631-25070c27fc04">

