### PR TITLE
Remove TODO from manifest now that we allow uploading manifest without webhook URL

### DIFF
--- a/examples/chem-sync-local-flask/manifest.yaml
+++ b/examples/chem-sync-local-flask/manifest.yaml
@@ -2,13 +2,9 @@ manifestVersion: 1
 
 info:
   name: Sample Sync App
-  # TODO We can't specify a version while also specifying a webhookUrl
-  # We can't specify a feature without specifying webhookUrl
-  # version: 0.1.0
+  version: 0.1.0
 settings:
   lifecycleManagement: MANUAL
-  # TODO: Just a placeholder, we'll replace with a valid webhook URL in the Benchling UI
-  webhookUrl: https://benchling.com
 features:
   - name: Sync Step
     id: sync_step


### PR DESCRIPTION
Benchling recently landed a change allowing for App Manifests to be uploaded without specifying a `webhookUrl` even though the App's features or subscriptions require it.

This allows for deferral of setting the webhook URL in the UI after the App has been created.