### PR TITLE
Upgrade benchling-sdk to 1.10.0 stable release

### DIFF
--- a/examples/chem-sync-local-flask/requirements.txt
+++ b/examples/chem-sync-local-flask/requirements.txt
@@ -1,4 +1,3 @@
 flask~=3.0.0
-# TODO Upgrade to stable SDK version once changes are released
 # Cryptography extra needed for webhook verification
-benchling-sdk[cryptography]==1.10.0a11
+benchling-sdk[cryptography]==1.10.0


### PR DESCRIPTION
Update the Benching SDK dependency for `chemi-sync-local-flask` to a stable version (1.10.0).