### PR TITLE
Add host network to dev container

### DIFF
--- a/examples/chem-sync-local-flask/.devcontainer/devcontainer.json
+++ b/examples/chem-sync-local-flask/.devcontainer/devcontainer.json
@@ -3,6 +3,9 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
+  "runArgs": [
+    "--network=host"
+  ],
   "remoteUser": "nonroot",
   "customizations": {
     "vscode": {


### PR DESCRIPTION
Adds `"--network=host"` to the Docker CLI args passed from the dev container. This enables IDE terminals such as within VSCode to be on the same network as the Docker compose for the application.

A common "gotcha" previously was IDE terminals not being able to reach those containers (e.g., `curl localhost:8000/health`).

After this change:

<img width="670" alt="Screenshot 2024-03-22 at 12 00 48 PM" src="https://github.com/benchling/app-examples-python/assets/1076765/fe67fed9-d29a-4a94-be72-3f7d459f15cc">
