### PR TITLE
V2 webhook updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@
 **/.pytest_cache
 .mypy_cache
 .ruff_cache
-**/.nvm/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 **/.pytest_cache
 .mypy_cache
 .ruff_cache
+**/.nvm/

--- a/examples/chem-sync-local-flask/local_app/benchling_app/canvas_interaction.py
+++ b/examples/chem-sync-local-flask/local_app/benchling_app/canvas_interaction.py
@@ -6,7 +6,7 @@ from benchling_sdk.apps.canvas.framework import CanvasBuilder
 from benchling_sdk.apps.framework import App
 from benchling_sdk.apps.status.errors import AppUserFacingError
 from benchling_sdk.models import AppCanvasUpdate, Molecule
-from benchling_sdk.models.webhooks.v0 import CanvasInteractionWebhookV0
+from benchling_sdk.models.webhooks.v0 import CanvasInteractionWebhookV2
 
 from local_app.benchling_app.molecules import create_molecule
 from local_app.benchling_app.views.canvas_initialize import input_blocks
@@ -29,7 +29,7 @@ class UnsupportedButtonError(Exception):
     pass
 
 
-def route_interaction_webhook(app: App, canvas_interaction: CanvasInteractionWebhookV0) -> None:
+def route_interaction_webhook(app: App, canvas_interaction: CanvasInteractionWebhookV2) -> None:
     canvas_id = canvas_interaction.canvas_id
     if canvas_interaction.button_id == SEARCH_BUTTON_ID:
         with app.create_session_context("Search Chemicals", timeout_seconds=20) as session:

--- a/examples/chem-sync-local-flask/local_app/benchling_app/handler.py
+++ b/examples/chem-sync-local-flask/local_app/benchling_app/handler.py
@@ -2,8 +2,8 @@ from typing import Any
 
 from benchling_sdk.apps.status.errors import AppUserFacingError
 from benchling_sdk.models.webhooks.v0 import (
-    CanvasInitializeWebhookV0,
-    CanvasInteractionWebhookV0,
+    CanvasInitializeWebhookV2,
+    CanvasInteractionWebhookV2,
     WebhookEnvelopeV0,
 )
 
@@ -27,9 +27,9 @@ def handle_webhook(webhook_dict: dict[str, Any]) -> None:
     # Note: if your manifest specifies more than one item in `features`,
     # then `webhook.message.feature_id` may also need to be part of your routing logic
     try:
-        if isinstance(webhook.message, CanvasInitializeWebhookV0):
+        if isinstance(webhook.message, CanvasInitializeWebhookV2):
             render_search_canvas(app, webhook.message)
-        elif isinstance(webhook.message, CanvasInteractionWebhookV0):
+        elif isinstance(webhook.message, CanvasInteractionWebhookV2):
             route_interaction_webhook(app, webhook.message)
         else:
             # Should only happen if the app's manifest requests webhooks that aren't handled in its code paths

--- a/examples/chem-sync-local-flask/local_app/benchling_app/views/canvas_initialize.py
+++ b/examples/chem-sync-local-flask/local_app/benchling_app/views/canvas_initialize.py
@@ -9,12 +9,12 @@ from benchling_sdk.models import (
     TextInputUiBlock,
     TextInputUiBlockType,
 )
-from benchling_sdk.models.webhooks.v0 import CanvasInitializeWebhookV0
+from benchling_sdk.models.webhooks.v0 import CanvasInitializeWebhookV2
 
 from local_app.benchling_app.views.constants import SEARCH_BUTTON_ID, SEARCH_TEXT_ID
 
 
-def render_search_canvas(app: App, canvas_initialized: CanvasInitializeWebhookV0) -> None:
+def render_search_canvas(app: App, canvas_initialized: CanvasInitializeWebhookV2) -> None:
     with app.create_session_context("Show Sync Search", timeout_seconds=20):
         canvas_builder = CanvasBuilder(
             app_id=app.id,

--- a/examples/chem-sync-local-flask/manifest.yaml
+++ b/examples/chem-sync-local-flask/manifest.yaml
@@ -7,7 +7,11 @@ features:
   - name: Sync Step
     id: sync_step
     type: ASSAY_RUN
-
+subscriptions:
+  deliveryMethod: WEBHOOK
+  messages:
+  - type: v2.canvas.initialized
+  - type: v2.canvas.userInteracted
 configuration:
   - name: Sync Folder
     type: folder

--- a/examples/chem-sync-local-flask/requirements.txt
+++ b/examples/chem-sync-local-flask/requirements.txt
@@ -1,3 +1,3 @@
 flask~=3.0.2
 # Cryptography extra needed for webhook verification
-benchling-sdk[cryptography]==1.12.0
+benchling-sdk[cryptography]==1.13.0

--- a/examples/chem-sync-local-flask/tests/files/webhooks/canvas_initialize_webhook.json
+++ b/examples/chem-sync-local-flask/tests/files/webhooks/canvas_initialize_webhook.json
@@ -13,7 +13,7 @@
   "message": {
     "featureId": "feat_1234",
     "resourceId": "assayrun_1234",
-    "type": "v0.canvas.initialized",
+    "type": "v2.canvas.initialized",
     "deprecated": false,
     "excludedProperties": []
   }

--- a/examples/chem-sync-local-flask/tests/files/webhooks/canvas_interaction_webhook.json
+++ b/examples/chem-sync-local-flask/tests/files/webhooks/canvas_interaction_webhook.json
@@ -11,7 +11,7 @@
   },
   "channel": "app_signals",
   "message": {
-    "type": "v0.canvas.userInteracted",
+    "type": "v2.canvas.userInteracted",
     "buttonId": "button_1",
     "canvasId": "cnvs_1234",
     "deprecated": false,

--- a/examples/chem-sync-local-flask/tests/unit/local_app/benchling_app/test_canvas_interaction.py
+++ b/examples/chem-sync-local-flask/tests/unit/local_app/benchling_app/test_canvas_interaction.py
@@ -11,7 +11,7 @@ from benchling_sdk.apps.status.errors import AppUserFacingError
 from benchling_sdk.apps.status.framework import SessionContextManager
 from benchling_sdk.apps.types import JsonType
 from benchling_sdk.models import AppCanvas, AppCanvasUpdate, Molecule, TextInputUiBlock
-from benchling_sdk.models.webhooks.v0 import CanvasInteractionWebhookV0
+from benchling_sdk.models.webhooks.v0 import CanvasInteractionWebhookV2
 
 from local_app.benchling_app.canvas_interaction import UnsupportedButtonError, route_interaction_webhook
 from local_app.benchling_app.views.canvas_initialize import input_blocks
@@ -191,8 +191,8 @@ def _mock_canvas(blocks: list[UiBlock] | None = None, data: JsonType | None = No
     return mock_canvas
 
 
-def _mock_interaction_webhook(canvas_id: str, button_id: str) -> CanvasInteractionWebhookV0:
-    interaction_webhook = MagicMock(CanvasInteractionWebhookV0)
+def _mock_interaction_webhook(canvas_id: str, button_id: str) -> CanvasInteractionWebhookV2:
+    interaction_webhook = MagicMock(CanvasInteractionWebhookV2)
     interaction_webhook.button_id = button_id
     interaction_webhook.canvas_id = canvas_id
     return interaction_webhook


### PR DESCRIPTION
- Bumping benchling-sdk to v1.13.0 for updated webhook models
- Updating handler.py to use V2 webhooks ahead of V0 deprecation (https://docs.benchling.com/changelog/explicit-webhook-subscriptions-and-webhook-version-update)