### PR TITLE
add notebook canvas

### DIFF
--- a/examples/chem-sync-local-flask/local_app/app.py
+++ b/examples/chem-sync-local-flask/local_app/app.py
@@ -25,7 +25,7 @@ def create_app() -> Flask:
 
         # Important! To verify webhooks, we need to pass the body as an unmodified string
         # Flask's request.data is bytes, so decode to string. Passing bytes or JSON won't work
-        verify(app_def_id, request.data.decode("utf-8"), request.headers) # type: ignore[arg-code]
+        verify(app_def_id, request.data.decode("utf-8"), request.headers) # type: ignore[arg-type]
 
         logger.debug("Received webhook message: %s", request.json)
         # Dispatch work and ACK webhook as quickly as possible

--- a/examples/chem-sync-local-flask/local_app/app.py
+++ b/examples/chem-sync-local-flask/local_app/app.py
@@ -25,7 +25,7 @@ def create_app() -> Flask:
 
         # Important! To verify webhooks, we need to pass the body as an unmodified string
         # Flask's request.data is bytes, so decode to string. Passing bytes or JSON won't work
-        verify(app_def_id, request.data.decode("utf-8"), request.headers) # type: ignore[arg-type]
+        verify(app_def_id, request.data.decode("utf-8"), request.headers) # type: ignore[arg-type] 
 
         logger.debug("Received webhook message: %s", request.json)
         # Dispatch work and ACK webhook as quickly as possible

--- a/examples/chem-sync-local-flask/local_app/app.py
+++ b/examples/chem-sync-local-flask/local_app/app.py
@@ -25,7 +25,7 @@ def create_app() -> Flask:
 
         # Important! To verify webhooks, we need to pass the body as an unmodified string
         # Flask's request.data is bytes, so decode to string. Passing bytes or JSON won't work
-        verify(app_def_id, request.data.decode("utf-8"), request.headers) # type: ignore
+        verify(app_def_id, request.data.decode("utf-8"), request.headers) # type: ignore[arg-code]
 
         logger.debug("Received webhook message: %s", request.json)
         # Dispatch work and ACK webhook as quickly as possible

--- a/examples/chem-sync-local-flask/local_app/app.py
+++ b/examples/chem-sync-local-flask/local_app/app.py
@@ -25,7 +25,7 @@ def create_app() -> Flask:
 
         # Important! To verify webhooks, we need to pass the body as an unmodified string
         # Flask's request.data is bytes, so decode to string. Passing bytes or JSON won't work
-        verify(app_def_id, request.data.decode("utf-8"), request.headers) # type: ignore[arg-type] 
+        verify(app_def_id, request.data.decode("utf-8"), request.headers) # type: ignore[arg-type]
 
         logger.debug("Received webhook message: %s", request.json)
         # Dispatch work and ACK webhook as quickly as possible

--- a/examples/chem-sync-local-flask/local_app/app.py
+++ b/examples/chem-sync-local-flask/local_app/app.py
@@ -25,7 +25,7 @@ def create_app() -> Flask:
 
         # Important! To verify webhooks, we need to pass the body as an unmodified string
         # Flask's request.data is bytes, so decode to string. Passing bytes or JSON won't work
-        verify(app_def_id, request.data.decode("utf-8"), request.headers)
+        verify(app_def_id, request.data.decode("utf-8"), request.headers) # type: ignore
 
         logger.debug("Received webhook message: %s", request.json)
         # Dispatch work and ACK webhook as quickly as possible

--- a/examples/chem-sync-local-flask/local_app/benchling_app/views/canvas_initialize.py
+++ b/examples/chem-sync-local-flask/local_app/benchling_app/views/canvas_initialize.py
@@ -18,6 +18,7 @@ def _canvas_builder_from_canvas_id(app: App, canvas_id: str) -> CanvasBuilder:
     current_canvas = app.benchling.apps.get_canvas_by_id(canvas_id)
     return CanvasBuilder.from_canvas(current_canvas)
 
+
 def render_search_canvas(app: App, canvas_initialized: CanvasInitializeWebhookV2) -> None:
     with app.create_session_context("Show Sync Search", timeout_seconds=20):
         canvas_builder = CanvasBuilder(
@@ -27,6 +28,7 @@ def render_search_canvas(app: App, canvas_initialized: CanvasInitializeWebhookV2
         )
         canvas_builder.blocks.append(input_blocks())
         app.benchling.apps.create_canvas(canvas_builder.to_create())
+
 
 def render_search_canvas_for_created_canvas(app: App, canvas_id: str) -> None:
     with app.create_session_context("Show Sync Search", timeout_seconds=20):

--- a/examples/chem-sync-local-flask/local_app/benchling_app/views/canvas_initialize.py
+++ b/examples/chem-sync-local-flask/local_app/benchling_app/views/canvas_initialize.py
@@ -14,6 +14,10 @@ from benchling_sdk.models.webhooks.v0 import CanvasInitializeWebhookV2
 from local_app.benchling_app.views.constants import SEARCH_BUTTON_ID, SEARCH_TEXT_ID
 
 
+def _canvas_builder_from_canvas_id(app: App, canvas_id: str) -> CanvasBuilder:
+    current_canvas = app.benchling.apps.get_canvas_by_id(canvas_id)
+    return CanvasBuilder.from_canvas(current_canvas)
+
 def render_search_canvas(app: App, canvas_initialized: CanvasInitializeWebhookV2) -> None:
     with app.create_session_context("Show Sync Search", timeout_seconds=20):
         canvas_builder = CanvasBuilder(
@@ -23,6 +27,12 @@ def render_search_canvas(app: App, canvas_initialized: CanvasInitializeWebhookV2
         )
         canvas_builder.blocks.append(input_blocks())
         app.benchling.apps.create_canvas(canvas_builder.to_create())
+
+def render_search_canvas_for_created_canvas(app: App, canvas_id: str) -> None:
+    with app.create_session_context("Show Sync Search", timeout_seconds=20):
+        canvas_builder = _canvas_builder_from_canvas_id(app, canvas_id)
+        canvas_builder.blocks.append(input_blocks())
+        app.benchling.apps.update_canvas(canvas_id, canvas_builder.to_update())
 
 
 def input_blocks() -> list[UiBlock]:

--- a/examples/chem-sync-local-flask/manifest.yaml
+++ b/examples/chem-sync-local-flask/manifest.yaml
@@ -1,8 +1,8 @@
 manifestVersion: 1
 
 info:
-  name: Sample Sync App - Notebook Canvas
-  version: 0.1.1
+  name: Sample Sync App
+  version: 0.1.0
 features:
   - name: Sync Step
     id: sync_step

--- a/examples/chem-sync-local-flask/manifest.yaml
+++ b/examples/chem-sync-local-flask/manifest.yaml
@@ -1,17 +1,21 @@
 manifestVersion: 1
 
 info:
-  name: Sample Sync App
-  version: 0.1.0
+  name: Sample Sync App - Notebook Canvas
+  version: 0.1.1
 features:
   - name: Sync Step
     id: sync_step
     type: ASSAY_RUN
+  - name: Sync Step
+    id: canvas_sync_step
+    type: CANVAS
 subscriptions:
   deliveryMethod: WEBHOOK
   messages:
   - type: v2.canvas.initialized
   - type: v2.canvas.userInteracted
+  - type: v2-beta.canvas.created
 configuration:
   - name: Sync Folder
     type: folder


### PR DESCRIPTION
Updated app to allow canvas to be added to notebook. This requires handling the `v2-beta.canvas.created` webhook, and replacing the automatically created canvas with our one. 