### PR TITLE
Use updated CanvasBuilder, revert type checking workaround for verify

### DIFF
--- a/examples/chem-sync-local-flask/local_app/app.py
+++ b/examples/chem-sync-local-flask/local_app/app.py
@@ -25,7 +25,7 @@ def create_app() -> Flask:
 
         # Important! To verify webhooks, we need to pass the body as an unmodified string
         # Flask's request.data is bytes, so decode to string. Passing bytes or JSON won't work
-        verify(app_def_id, request.data.decode("utf-8"), request.headers) # type: ignore[arg-type]
+        verify(app_def_id, request.data.decode("utf-8"), request.headers)
 
         logger.debug("Received webhook message: %s", request.json)
         # Dispatch work and ACK webhook as quickly as possible

--- a/examples/chem-sync-local-flask/local_app/benchling_app/handler.py
+++ b/examples/chem-sync-local-flask/local_app/benchling_app/handler.py
@@ -36,7 +36,7 @@ def handle_webhook(webhook_dict: dict[str, Any]) -> None:
         elif isinstance(webhook.message, CanvasInteractionWebhookV2):
             route_interaction_webhook(app, webhook.message)
         elif isinstance(webhook.message, CanvasCreatedWebhookV2Beta):
-            render_search_canvas_for_created_canvas(app, webhook.message.canvas_id)
+            render_search_canvas_for_created_canvas(app, webhook.message)
         else:
             # Should only happen if the app's manifest requests webhooks that aren't handled in its code paths
             raise UnsupportedWebhookError(f"Received an unsupported webhook type: {webhook}")

--- a/examples/chem-sync-local-flask/local_app/benchling_app/views/canvas_initialize.py
+++ b/examples/chem-sync-local-flask/local_app/benchling_app/views/canvas_initialize.py
@@ -9,14 +9,13 @@ from benchling_sdk.models import (
     TextInputUiBlock,
     TextInputUiBlockType,
 )
-from benchling_sdk.models.webhooks.v0 import CanvasInitializeWebhookV2
+from benchling_sdk.models.webhooks.v0 import (
+    CanvasCreatedWebhookV2Beta,
+    CanvasInitializeWebhookV2,
+)
 
 from local_app.benchling_app.views.constants import SEARCH_BUTTON_ID, SEARCH_TEXT_ID
 
-
-def _canvas_builder_from_canvas_id(app: App, canvas_id: str) -> CanvasBuilder:
-    current_canvas = app.benchling.apps.get_canvas_by_id(canvas_id)
-    return CanvasBuilder.from_canvas(current_canvas)
 
 def render_search_canvas(app: App, canvas_initialized: CanvasInitializeWebhookV2) -> None:
     with app.create_session_context("Show Sync Search", timeout_seconds=20):
@@ -29,11 +28,11 @@ def render_search_canvas(app: App, canvas_initialized: CanvasInitializeWebhookV2
         app.benchling.apps.create_canvas(canvas_builder.to_create())
 
 
-def render_search_canvas_for_created_canvas(app: App, canvas_id: str) -> None:
+def render_search_canvas_for_created_canvas(app: App, canvas_created: CanvasCreatedWebhookV2Beta) -> None:
     with app.create_session_context("Show Sync Search", timeout_seconds=20):
-        canvas_builder = _canvas_builder_from_canvas_id(app, canvas_id)
+        canvas_builder = CanvasBuilder(app_id=app.id, feature_id=canvas_created.feature_id)
         canvas_builder.blocks.append(input_blocks())
-        app.benchling.apps.update_canvas(canvas_id, canvas_builder.to_update())
+        app.benchling.apps.update_canvas(canvas_created.canvas_id, canvas_builder.to_update())
 
 
 def input_blocks() -> list[UiBlock]:

--- a/examples/chem-sync-local-flask/requirements.txt
+++ b/examples/chem-sync-local-flask/requirements.txt
@@ -1,3 +1,3 @@
 flask~=3.0.2
 # Cryptography extra needed for webhook verification
-benchling-sdk[cryptography]==1.19.0
+benchling-sdk[cryptography]==1.21.0

--- a/examples/chem-sync-local-flask/requirements.txt
+++ b/examples/chem-sync-local-flask/requirements.txt
@@ -1,3 +1,3 @@
 flask~=3.0.2
 # Cryptography extra needed for webhook verification
-benchling-sdk[cryptography]==1.21.0
+benchling-sdk[cryptography]==1.21.1


### PR DESCRIPTION
Updating to Benchling SDK v1.21.1 which fixes the issue with request.headers needing to be a `dict`. 

More info on the SDK update [here](https://github.com/benchling/benchling-sdk/pull/611).