### PR TITLE
Switch webhook tunnel to cloudflare

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The `examples/` directory contains Benchling App samples written by Benchling.
 Demonstrates creating a custom UI in Benchling allowing users to search for 
 molecules from [PubChem](https://pubchem.ncbi.nlm.nih.gov/) and sync them into Benchling.
 
-Uses [localtunnel](https://localtunnel.me/) and [Docker](https://www.docker.com/) to receive webhooks 
+Uses [Cloudflare Tunnel](https://www.cloudflare.com/products/tunnel/) and [Docker](https://www.docker.com/) to receive webhooks 
 in a local development environment running [Flask](https://flask.palletsprojects.com/) with the 
 [Benchling SDK](https://docs.benchling.com/docs/getting-started-with-the-sdk).
 

--- a/examples/chem-sync-local-flask/Dockerfile.localtunnel
+++ b/examples/chem-sync-local-flask/Dockerfile.localtunnel
@@ -1,5 +1,0 @@
-FROM node:21-alpine
-RUN npm install -g localtunnel@2.0.2
-
-# Note: This might not work with some networks. For instance, random airplane WiFi
-CMD lt --port 5000 --local-host benchling-app --print-requests

--- a/examples/chem-sync-local-flask/README.md
+++ b/examples/chem-sync-local-flask/README.md
@@ -16,7 +16,7 @@ This app is optimized as a minimal local development experience using [Docker](h
 > ⚠️ **Development Only**: This example is not meant to be copied into production as-is. There are additional deployment, scale, and security concerns that should be addressed before deploying an app based on this example to production.
 
 It relies on a few other tools that will be installed for you within Docker containers:
-* [Localtunnel](https://localtunnel.me/) - expose a public webhook URL and forward the results locally. ⚠️ *Not for production or real data!*
+* [Cloudflare Tunnel](https://www.cloudflare.com/products/tunnel/) - expose a public webhook URL and forward the results locally. ⚠️ *Not for production or real data!*
 * [Flask](https://flask.palletsprojects.com/) - A simple Python web application framework
 
 ## Getting Started
@@ -54,25 +54,28 @@ curl localhost:8000/health
 
 If Flask is running, you should see `OK` printed.
 
-Be sure to note the URL created for you by `localtunnel`. The log line should look something like this:
+Be sure to note the URL created for you by `Cloudflare Tunnel`. The log line should look something like this:
 
 ```
-app-workshop-local-tunnel-1   | your url is: https://brave-wombats-poke.loca.lt
+cloudflare-tunnel-1  | +--------------------------------------------------------------------------------------------+
+cloudflare-tunnel-1  | |  Your quick Tunnel has been created! Visit it at (it may take some time to be reachable):  |
+cloudflare-tunnel-1  | |  https://brave-wombats-poke.trycloudflare.com                                              |
+cloudflare-tunnel-1  | +--------------------------------------------------------------------------------------------+
 ```
 
 On *nix systems, you can easily obtain _just_ the URL via:
 
 ```
-docker compose logs local-tunnel | grep -o https://.* | tail -n 1
+docker compose logs cloudflare-tunnel | grep -o https://.* | tail -n 1
 ```
 
 Example Output:
 
 ```
-https://brave-wombats-poke.loca.lt
+https://brave-wombats-poke.trycloudflare.com
 ```
 
-> 💡 Don't forget to append `/1/webhooks`, making the full URL given to Benchling `https://brave-wombats-poke.loca.lt/1/webhooks`
+> 💡 Don't forget to append `/1/webhooks`, making the full URL given to Benchling `https://brave-wombats-poke.trycloudflare.com/1/webhooks`
 
 ## Setting Up Your App in Benchling
 
@@ -95,17 +98,17 @@ When prompted to upload a file, select `manifest.yaml` and click "Create."
 
 ### Update the Webhook URL
 
-Every time we restart the `local-tunnel` Docker container, it will provision
+Every time we restart the `cloudflare-tunnel` Docker container, it will provision
 a new public webhook URL.
 
 Update the Benchling App's Webhook URL in the UI with the new server and
 append the path our Flask route expects (see `local_app/app.py`).
 
-For example, if our `localtunnel` generated URL is `https://hot-ideas-doubt.loca.lt`,
+For example, if our `cloudflare` generated URL is `https://hot-ideas-doubt.trycloudflare.com`,
 the webhook URL in Benchling should be:
 
 ```
-https://hot-ideas-doubt.loca.lt/1/webhooks
+https://hot-ideas-doubt.trycloudflare.com/1/webhooks
 ```
 
 ![image info](./docs/update-webhook-url.gif)

--- a/examples/chem-sync-local-flask/docker-compose.yaml
+++ b/examples/chem-sync-local-flask/docker-compose.yaml
@@ -29,10 +29,10 @@ services:
   # Do not do this in production or use with any sensitive data.
   # Benchling has not vetted this tool for use in production or in sensitive systems.
   # Conduct your own due diligence before choosing a tool for production use.
-  local-tunnel:
-    build:
-      context: .
-      dockerfile: Dockerfile.localtunnel
+  cloudflare-tunnel:
+    image: cloudflare/cloudflared
+    restart: unless-stopped
+    command: tunnel --url http://benchling-app:5000
 
 secrets:
   app_client_secret:


### PR DESCRIPTION
* Update to use cloudflare tunnel in place of localtunnel for webhook routing
* Docs also updated to reflect this change