### PR TITLE
Benchtalk workshop embeddable canvas

### DIFF
--- a/examples/chem-sync-local-flask/local_app/benchling_app/handler.py
+++ b/examples/chem-sync-local-flask/local_app/benchling_app/handler.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from benchling_sdk.apps.status.errors import AppUserFacingError
 from benchling_sdk.models.webhooks.v0 import (
+    CanvasCreatedWebhookV2Beta,
     CanvasInitializeWebhookV2,
     CanvasInteractionWebhookV2,
     WebhookEnvelopeV0,
@@ -9,7 +10,10 @@ from benchling_sdk.models.webhooks.v0 import (
 
 from local_app.benchling_app.canvas_interaction import route_interaction_webhook
 from local_app.benchling_app.setup import init_app_from_webhook
-from local_app.benchling_app.views.canvas_initialize import render_search_canvas
+from local_app.benchling_app.views.canvas_initialize import (
+    render_search_canvas,
+    render_search_canvas_for_created_canvas,
+)
 from local_app.lib.logger import get_logger
 
 logger = get_logger()
@@ -29,6 +33,8 @@ def handle_webhook(webhook_dict: dict[str, Any]) -> None:
     try:
         if isinstance(webhook.message, CanvasInitializeWebhookV2):
             render_search_canvas(app, webhook.message)
+        elif isinstance(webhook.message, CanvasCreatedWebhookV2Beta):
+            render_search_canvas_for_created_canvas(app, webhook.message)
         # elif isinstance(webhook.message, CanvasInteractionWebhookV2):
         #     route_interaction_webhook(app, webhook.message)
         # else:

--- a/examples/chem-sync-local-flask/local_app/benchling_app/views/canvas_initialize.py
+++ b/examples/chem-sync-local-flask/local_app/benchling_app/views/canvas_initialize.py
@@ -9,7 +9,7 @@ from benchling_sdk.models import (
     TextInputUiBlock,
     TextInputUiBlockType,
 )
-from benchling_sdk.models.webhooks.v0 import CanvasInitializeWebhookV2
+from benchling_sdk.models.webhooks.v0 import CanvasInitializeWebhookV2, CanvasCreatedWebhookV2Beta
 
 from local_app.benchling_app.views.constants import SEARCH_BUTTON_ID, SEARCH_TEXT_ID
 
@@ -37,6 +37,27 @@ def render_search_canvas(app: App, canvas_initialized: CanvasInitializeWebhookV2
     #     )
     #     canvas_builder.blocks.append(input_blocks())
     #     app.benchling.apps.create_canvas(canvas_builder.to_create())
+
+
+def render_search_canvas_for_created_canvas(app: App, canvas_created: CanvasCreatedWebhookV2Beta) -> None:
+    canvas_builder = CanvasBuilder(
+        app_id=app.id,
+        feature_id=canvas_created.feature_id,
+        resource_id=canvas_created.resource_id,
+        blocks=[
+            MarkdownUiBlock(
+                type=MarkdownUiBlockType.MARKDOWN,
+                value="**Hello world!!**",
+            ),
+            # TODO: Let's add a button to Hello World
+        ],
+    )
+    app.benchling.apps.update_canvas(canvas_created.canvas_id, canvas_builder.to_update())
+
+    # with app.create_session_context("Show Sync Search", timeout_seconds=20):
+    #     canvas_builder = CanvasBuilder(app_id=app.id, feature_id=canvas_created.feature_id)
+    #     canvas_builder.blocks.append(input_blocks())
+    #     app.benchling.apps.update_canvas(canvas_created.canvas_id, canvas_builder.to_update())
 
 
 def input_blocks() -> list[UiBlock]:

--- a/examples/chem-sync-local-flask/manifest.yaml
+++ b/examples/chem-sync-local-flask/manifest.yaml
@@ -6,11 +6,15 @@ features:
   - name: Sync Step
     id: sync_step
     type: ASSAY_RUN
+  - name: Sync Step
+    id: canvas_sync_step
+    type: CANVAS
 subscriptions:
   deliveryMethod: WEBHOOK
   messages:
   - type: v2.canvas.initialized
   - type: v2.canvas.userInteracted
+  - type: v2-beta.canvas.created
 configuration:
   - name: Sync Folder
     type: folder

--- a/examples/chem-sync-local-flask/requirements.txt
+++ b/examples/chem-sync-local-flask/requirements.txt
@@ -1,3 +1,3 @@
 flask~=3.0.2
 # Cryptography extra needed for webhook verification
-benchling-sdk[cryptography]==1.13.0
+benchling-sdk[cryptography]==1.21.2


### PR DESCRIPTION
Handful of updates to support embeddable canvases:
* Updated SDK version to 1.21.1
* Support for `v2-beta.canvas.created` webhook
* Import CanvasCreatedWebhookV2Beta in relevant places
* New `render_search_canvas_for_created_canvas` function
* New path in `handler.py` for embeddable canvases
* Updated `manifest.yaml` to include `CANVAS` feature