### PR TITLE
Fix caching of ClientCredentialsOauth2 object when deployed on multiple tenants.

### DIFF
--- a/examples/chem-sync-local-flask/local_app/benchling_app/setup.py
+++ b/examples/chem-sync-local-flask/local_app/benchling_app/setup.py
@@ -27,11 +27,11 @@ def app_definition_id() -> str:
 
 
 def _benchling_from_webhook(webhook: WebhookEnvelopeV0) -> Benchling:
-    return Benchling(webhook.base_url, _auth_method())
+    return Benchling(webhook.base_url, _auth_method(webhook.baseurl))
 
 
 @cache
-def _auth_method() -> ClientCredentialsOAuth2:
+def _auth_method(base_url) -> ClientCredentialsOAuth2:
     client_id = os.environ.get("CLIENT_ID")
     assert client_id is not None, "Missing CLIENT_ID from environment"
     client_secret = _client_secret_from_file()


### PR DESCRIPTION
If this app is published in two tenants, the caching of _auth_method() will mean the same ClientCredentialsOauth2 object is used for both tenants. This causes an intermittent authentication error issue. If tenant A requests a token, it is set for tenant B, and vice versa, until it is refreshed. 
This PR fixes that by passing the webhook.baseurl into _auth_method() thereby having a ClientCredentialsOauth2 object, per tenant, that is still cached as needed. There is no need to actually use webhook.baseurl, it is purely used for cache uniqueness.