### PR TITLE
Fix: tenant-specific caching for ClientCredentialsOAuth2

### DIFF
--- a/examples/chem-sync-local-flask/local_app/benchling_app/setup.py
+++ b/examples/chem-sync-local-flask/local_app/benchling_app/setup.py
@@ -27,11 +27,13 @@ def app_definition_id() -> str:
 
 
 def _benchling_from_webhook(webhook: WebhookEnvelopeV0) -> Benchling:
-    return Benchling(webhook.base_url, _auth_method())
+    # Pass webhook.base_url into _auth_method so each tenant has a unique cached object
+    return Benchling(webhook.base_url, _auth_method(webhook.base_url))
 
 
 @cache
-def _auth_method() -> ClientCredentialsOAuth2:
+def _auth_method(base_url: str) -> ClientCredentialsOAuth2:
+    # base_url is only used to make the cache key tenant-specific
     client_id = os.environ.get("CLIENT_ID")
     assert client_id is not None, "Missing CLIENT_ID from environment"
     client_secret = _client_secret_from_file()


### PR DESCRIPTION
This PR fixes an issue where ClientCredentialsOAuth2 objects were cached globally across tenants, causing tokens to overwrite each other when the app was deployed on multiple tenants.
By including webhook.base_url in the _auth_method() signature, the cache key becomes tenant-specific while still preserving caching efficiency.