### PR TITLE
update runner image to ubuntu-24.04

### DIFF
--- a/.github/workflows/chem-sync-local-flask-test.yaml
+++ b/.github/workflows/chem-sync-local-flask-test.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   test:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Quality Checks + Tests
     defaults:
       run:


### PR DESCRIPTION
Available images are listed in https://github.com/actions/runner-images#available-images 
`ubuntu-20.04` is no longer supported, causing new jobs to not get picked up or to run at all.